### PR TITLE
Wildcards in middleware paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ func LoginRequired(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 
 kami can use vanilla http middleware as well. `kami.Use` accepts functions in the form of `func(next http.Handler) http.Handler`. Be advised that kami will run such middleware in sequence, not in a chain. This means that standard loggers and panic handlers won't work as you expect. You should use `kami.LogHandler` and `kami.PanicHandler` instead.
 
-The following example uses `goji/httpauth` to add HTTP Basic Authentication to paths under `/secret/`.
+The following example uses [goji/httpauth](https://github.com/goji/httpauth) to add HTTP Basic Authentication to paths under `/secret/`.
 
 ```go
 import (

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 ## kami [![GoDoc](https://godoc.org/github.com/guregu/kami?status.svg)](https://godoc.org/github.com/guregu/kami) [![Coverage](http://gocover.io/_badge/github.com/guregu/kami?0)](http://gocover.io/github.com/guregu/kami)
 `import "github.com/guregu/kami"`
 
-kami (神) is a tiny web framework using [x/net/context](https://blog.golang.org/context) for request context, and [HttpRouter](https://github.com/julienschmidt/httprouter) for routing. It includes a simple system for running hierarchical middleware before requests, in addition to log and panic hooks. Graceful restart via einhorn is also supported.
+kami (神) is a tiny web framework using [x/net/context](https://blog.golang.org/context) for request context and [HttpRouter](https://github.com/julienschmidt/httprouter) for routing. It includes a simple system for running hierarchical middleware before requests, in addition to log and panic hooks. Graceful restart via einhorn is also supported.
 
 kami is designed to be used as central registration point for your routes, middleware, and context "god object", so kami has no concept of multiple muxes. 
 
 You are free to mount `kami.Handler()` wherever you wish, but a helpful `kami.Serve()` function is provided.
 
-Here's a presentation I did related to kami and x/net/context: http://go-talks.appspot.com/github.com/guregu/slides/kami/kami.slide
+Here is a [presentation about the birth of kami](http://go-talks.appspot.com/github.com/guregu/slides/kami/kami.slide), explaining some of the design choices. 
 
 ### Example
 
@@ -34,7 +34,7 @@ func main() {
 
 ### Usage
 
-* Set up routes using `kami.Get("path", handler)`, `kami.Post(...)`, etc. You can use named parameters in URLs like `/hello/:name`, and access them using the context kami gives you: `kami.Param(ctx, "name")`. The following kinds of handlers are accepted:
+* Set up routes using `kami.Get("path", handler)`, `kami.Post(...)`, etc. You can use [named parameters](https://github.com/julienschmidt/httprouter#named-parameters) or [wildcards](https://github.com/julienschmidt/httprouter#catch-all-parameters) in URLs like `/hello/:name/edit` or `/files/*path`, and access them using the context kami gives you: `kami.Param(ctx, "name")`. The following kinds of handlers are accepted:
   * types that implement `kami.ContextHandler`
   * `func(context.Context, http.ResponseWriter, *http.Request)`
   * types that implement `http.Handler`
@@ -80,6 +80,14 @@ func LoginRequired(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 	}
 	return ctx
 }	
+```
+
+#### Named parameters, wildcards, and middleware
+
+Named parameters and wildcards in middleware are supported now. Middleware registered under a path with a wildcard will run **after** all hierarchical middleware. 
+
+```go
+kami.Use("/user/:id/edit", CheckAdminPermissions)
 ```
 
 #### Vanilla net/http middleware

--- a/bench_test.go
+++ b/bench_test.go
@@ -17,7 +17,7 @@ func BenchmarkStaticRoute(b *testing.B) {
 		resp := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/hello", nil)
 		kami.Handler().ServeHTTP(resp, req)
-		if resp.Code != 200 {
+		if resp.Code != http.StatusOK {
 			panic(resp.Code)
 		}
 	}
@@ -34,7 +34,7 @@ func BenchmarkParameter(b *testing.B) {
 		resp := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/hello/bob", nil)
 		kami.Handler().ServeHTTP(resp, req)
-		if resp.Code != 200 {
+		if resp.Code != http.StatusOK {
 			panic(resp.Code)
 		}
 	}
@@ -51,7 +51,7 @@ func BenchmarkParameter5(b *testing.B) {
 		resp := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/a/b/c/d/e", nil)
 		kami.Handler().ServeHTTP(resp, req)
-		if resp.Code != 200 {
+		if resp.Code != http.StatusOK {
 			panic(resp.Code)
 		}
 	}
@@ -66,14 +66,14 @@ func BenchmarkMiddleware(b *testing.B) {
 	})
 	kami.Get("/test", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		if ctx.Value("test") != "ok" {
-			w.WriteHeader(501)
+			w.WriteHeader(http.StatusServiceUnavailable)
 		}
 	})
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/test", nil)
 		kami.Handler().ServeHTTP(resp, req)
-		if resp.Code != 200 {
+		if resp.Code != http.StatusOK {
 			panic(resp.Code)
 		}
 	}
@@ -91,7 +91,7 @@ func BenchmarkMiddleware5(b *testing.B) {
 	kami.Get("/test", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		for _, n := range numbers {
 			if ctx.Value(n) != n {
-				w.WriteHeader(501)
+				w.WriteHeader(http.StatusServiceUnavailable)
 				return
 			}
 		}
@@ -100,7 +100,7 @@ func BenchmarkMiddleware5(b *testing.B) {
 		resp := httptest.NewRecorder()
 		req, _ := http.NewRequest("GET", "/test", nil)
 		kami.Handler().ServeHTTP(resp, req)
-		if resp.Code != 200 {
+		if resp.Code != http.StatusOK {
 			panic(resp.Code)
 		}
 	}

--- a/kami.go
+++ b/kami.go
@@ -110,7 +110,7 @@ func bless(k ContextHandler) httprouter.Handle {
 					if LogHandler != nil && !ranLogHandler {
 						LogHandler(ctx, proxy, r)
 						// should only happen if header hasn't been written
-						proxy.WriteHeader(500)
+						proxy.WriteHeader(http.StatusInternalServerError)
 					}
 				}
 			}()
@@ -125,7 +125,7 @@ func bless(k ContextHandler) httprouter.Handle {
 			ranLogHandler = true
 			LogHandler(ctx, proxy, r)
 			// should only happen if header hasn't been written
-			proxy.WriteHeader(500)
+			proxy.WriteHeader(http.StatusInternalServerError)
 		}
 	}
 }

--- a/kami_test.go
+++ b/kami_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/zenazn/goji/web/mutil"
@@ -13,7 +14,7 @@ import (
 	"github.com/guregu/kami"
 )
 
-func TestParams(t *testing.T) {
+func TestKami(t *testing.T) {
 	kami.Reset()
 	kami.Use("/", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
 		return context.WithValue(ctx, "test1", "1")
@@ -69,8 +70,8 @@ func TestLoggerAndPanic(t *testing.T) {
 		if err != "test panic" {
 			t.Error("unexpected exception:", err)
 		}
-		w.WriteHeader(500)
-		w.Write([]byte("error 500"))
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte("error 503"))
 	})
 	kami.Post("/test", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		panic("test panic")
@@ -79,33 +80,15 @@ func TestLoggerAndPanic(t *testing.T) {
 		w.WriteHeader(200)
 	})
 
-	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("POST", "/test", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	kami.Handler().ServeHTTP(resp, req)
-	if resp.Code != 500 {
-		t.Error("should return HTTP 500", resp.Code, "≠", 500)
-	}
-	if status != 500 {
-		t.Error("should return HTTP 500", status, "≠", 500)
+	expectResponseCode(t, "POST", "/test", http.StatusServiceUnavailable)
+	if status != http.StatusServiceUnavailable {
+		t.Error("log handler received wrong status code", status, "≠", http.StatusServiceUnavailable)
 	}
 
 	// test loggers without panics
-	resp = httptest.NewRecorder()
-	req, err = http.NewRequest("PUT", "/ok", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	kami.Handler().ServeHTTP(resp, req)
-	if resp.Code != 200 {
-		t.Error("should return HTTP 200", resp.Code, "≠", 200)
-	}
+	expectResponseCode(t, "PUT", "/ok", http.StatusOK)
 	if status != 200 {
-		t.Error("should return HTTP 200", status, "≠", 200)
+		t.Error("log handler received wrong status code", status, "≠", http.StatusOK)
 	}
 }
 
@@ -121,21 +104,12 @@ func TestPanickingLogger(t *testing.T) {
 		if err != "test panic" {
 			t.Error("unexpected exception:", err)
 		}
-		w.WriteHeader(500)
-		w.Write([]byte("error 500"))
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte("error 503"))
 	})
 	kami.Post("/test", noop)
 
-	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("POST", "/test", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	kami.Handler().ServeHTTP(resp, req)
-	if resp.Code != 500 {
-		t.Error("should return HTTP 500", resp.Code, "≠", 500)
-	}
+	expectResponseCode(t, "POST", "/test", http.StatusServiceUnavailable)
 }
 
 func TestNotFound(t *testing.T) {
@@ -146,37 +120,37 @@ func TestNotFound(t *testing.T) {
 	kami.NotFound(func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		ok, _ := ctx.Value("ok").(bool)
 		if !ok {
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 		w.WriteHeader(420)
 	})
 
-	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/missing/hello", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	kami.Handler().ServeHTTP(resp, req)
-	if resp.Code != 420 {
-		t.Error("should return HTTP 420", resp.Code, "≠", 420)
-	}
+	expectResponseCode(t, "GET", "/missing/hello", 420)
 }
 
 func TestNotFoundDefault(t *testing.T) {
 	kami.Reset()
 
+	expectResponseCode(t, "GET", "/missing/hello", http.StatusNotFound)
+}
+
+func noop(ctx context.Context, w http.ResponseWriter, r *http.Request) {}
+
+func expectResponseCode(t *testing.T, method, path string, expected int) {
 	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/missing/hello", nil)
+	req, err := http.NewRequest(method, path, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	kami.Handler().ServeHTTP(resp, req)
-	if resp.Code != 404 {
-		t.Error("should return HTTP 404", resp.Code, "≠", 404)
+
+	text := http.StatusText(expected)
+	if text == "" {
+		text = strconv.Itoa(expected)
+	}
+	if resp.Code != expected {
+		t.Error("should return HTTP", text, resp.Code, "≠", expected)
 	}
 }
-
-func noop(ctx context.Context, w http.ResponseWriter, r *http.Request) {}

--- a/middleware.go
+++ b/middleware.go
@@ -42,7 +42,7 @@ var wildcardMW = new(tree.Node)                // wildcard middleware
 // Use kami.LogHandler and kami.PanicHandler instead.
 // Standard middleware that does not call the next handler to stop the request is supported.
 func Use(path string, mw MiddlewareType) {
-	if isWildcardPath(path) {
+	if containsWildcard(path) {
 		wildcardMW.AddRoute(path, convert(mw))
 	} else {
 		fn := convert(mw)
@@ -125,9 +125,6 @@ func (dh *dummyHandler) ServeHTTPContext(_ context.Context, _ http.ResponseWrite
 	*dh = true
 }
 
-func isWildcardPath(path string) bool {
-	if strings.Contains(path, "/:") || strings.Contains(path, "/*") {
-		return true
-	}
-	return false
+func containsWildcard(path string) bool {
+	return strings.Contains(path, "/:") || strings.Contains(path, "/*")
 }

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -1,0 +1,60 @@
+package kami_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/guregu/kami"
+	"golang.org/x/net/context"
+)
+
+func TestWildcardMiddleware(t *testing.T) {
+	kami.Reset()
+	kami.Use("/user/:mid/edit", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		if kami.Param(ctx, "mid") == "403" {
+			w.WriteHeader(http.StatusForbidden)
+			return nil
+		}
+
+		return context.WithValue(ctx, "middleware id", kami.Param(ctx, "mid"))
+	})
+	kami.Patch("/user/:id/edit", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		if kami.Param(ctx, "mid") != kami.Param(ctx, "id") {
+			t.Error("mid != id")
+		}
+
+		if ctx.Value("middleware id").(string) != kami.Param(ctx, "id") {
+			t.Error("middleware values not propagating")
+		}
+	})
+	kami.Head("/user/:id", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		if ctx.Value("middleware id") != nil {
+			t.Error("wildcard middleware shouldn't have been called")
+			w.WriteHeader(500)
+			return
+		}
+		w.WriteHeader(200)
+	})
+
+	// normal case
+	expectResponseCode(t, "PATCH", "/user/42/edit", http.StatusOK)
+
+	// should stop early
+	expectResponseCode(t, "PATCH", "/user/403/edit", http.StatusForbidden)
+
+	// make sure the middleware isn't over eager
+	expectResponseCode(t, "HEAD", "/user/403", http.StatusOK)
+}
+
+func TestHierarchicalStop(t *testing.T) {
+	kami.Reset()
+	kami.Use("/nope/", kami.Middleware(func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		w.WriteHeader(http.StatusForbidden)
+		return nil
+	}))
+	kami.Delete("/nope/test", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	expectResponseCode(t, "DELETE", "/nope/test", http.StatusForbidden)
+}

--- a/middleware_test.go
+++ b/middleware_test.go
@@ -30,10 +30,10 @@ func TestWildcardMiddleware(t *testing.T) {
 	kami.Head("/user/:id", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		if ctx.Value("middleware id") != nil {
 			t.Error("wildcard middleware shouldn't have been called")
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 	})
 
 	// normal case

--- a/params.go
+++ b/params.go
@@ -33,6 +33,12 @@ func newContextWithParams(ctx context.Context, params httprouter.Params) context
 	return context.WithValue(ctx, paramsKey, params)
 }
 
+func mergeParams(ctx context.Context, params httprouter.Params) context.Context {
+	current, _ := ctx.Value(paramsKey).(httprouter.Params)
+	current = append(current, params...)
+	return context.WithValue(ctx, paramsKey, current)
+}
+
 func newContextWithException(ctx context.Context, exception interface{}) context.Context {
 	return context.WithValue(ctx, panicKey, exception)
 }


### PR DESCRIPTION
You can now do:
`kami.Use("/secret/:id", middleware)`
and 
`kami.Param(ctx, "id")`
within the middleware to get the wildcard's value.


URL params and middleware params will get merged, so make sure you use different names for them.

### TODO:
- [x] Add tests
- [x] Docs