### PR TITLE
Make kami work out of the box on Google App Engine

### DIFF
--- a/context_appengine.go
+++ b/context_appengine.go
@@ -1,0 +1,14 @@
+// +build appengine
+
+package kami
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+	"google.golang.org/appengine"
+)
+
+func defaultContext(r *http.Request, c context.Context) context.Context {
+	return appengine.NewContext(r)
+}

--- a/context_standalone.go
+++ b/context_standalone.go
@@ -1,0 +1,13 @@
+// +build !appengine
+
+package kami
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+)
+
+func defaultContext(r *http.Request, c context.Context) context.Context {
+	return c
+}

--- a/kami.go
+++ b/kami.go
@@ -9,7 +9,9 @@ import (
 )
 
 var (
-	// Context is the root "god object" from which every request's context will derive
+	// Context is the root "god object" from which every request's context will derive.
+	// It is ignored on App Engine, where the request-specific App Engine context is used
+	// instead.
 	Context = context.Background()
 
 	// PanicHandler will, if set, be called on panics.
@@ -92,9 +94,9 @@ func defaultBless(k ContextHandler) httprouter.Handle {
 // in order to run all the middleware and other special handlers.
 func bless(k ContextHandler, base *context.Context, m *middlewares, panicHandler *HandlerType, logHandler *func(context.Context, mutil.WriterProxy, *http.Request)) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
-		ctx := *base
+		ctx := defaultContext(r, *base)
 		if len(params) > 0 {
-			ctx = newContextWithParams(Context, params)
+			ctx = newContextWithParams(ctx, params)
 		}
 		ranLogHandler := false // track this in case the log handler blows up
 

--- a/server.go
+++ b/server.go
@@ -12,6 +12,8 @@ import (
 type Server struct {
 	// Context is the root "god object" for this server,
 	// from which every request's context will derive.
+	// It is ignored on App Engine, where the request-specific
+	// App Engine context is used instead.
 	Context context.Context
 	// PanicHandler will, if set, be called on panics.
 	// You can use kami.Exception(ctx) within the panic handler to get panic details.


### PR DESCRIPTION
App Engine services require an App Engine -specific context, which needs to be created per-request using [`appengine.NewContext`][1]. Setting the "god context" thus doesn't work, so this pull request makes the handler returned by `bless` call `defaultContext(r, *base)` to get its context, which does the right thing depending on whether we build for App Engine or not.

[1]: https://godoc.org/google.golang.org/appengine#NewContext