### PR TITLE
ignore build on appengine

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -1,3 +1,5 @@
+// +build !appengine
+
 package kami
 
 import (


### PR DESCRIPTION
Hi.

When I deploy my application with the kami on the appengine, I caught the following error:

```
$ goapp deploy .
:
: snip
:
04:52 PM Error 422: --- begin server output ---
Compile failed:
2015/08/30 00:52:19 go-app-builder: Failed parsing input: parser: bad import "syscall" in github.com/zenazn/goji/graceful/einhorn.go
--- end server output ---
: snip
```

The kami use graceful package at serve.go. This package use syscall package, so compile failed.
So serve.go file ignore on appengine.

```
$ goapp version
go version go1.4.2 (appengine-1.9.25) darwin/amd64
```

Thanks.