### PR TITLE
MethodNotAllowed handler

### DIFF
--- a/kami.go
+++ b/kami.go
@@ -100,6 +100,11 @@ func MethodNotAllowed(handler HandlerType) {
 	}
 }
 
+// Toggle any invalid method request handling in httprouter
+func HandleMethodNotAllowed(value bool) {
+	routes.HandleMethodNotAllowed = value
+}
+
 func defaultBless(k ContextHandler) httprouter.Handle {
 	return bless(k, &Context, defaultMW, &PanicHandler, &LogHandler)
 }

--- a/kami.go
+++ b/kami.go
@@ -88,6 +88,18 @@ func NotFound(handler HandlerType) {
 	})
 }
 
+// MethodNotAllowed registers special handler for invalid method requests (405).
+func MethodNotAllowed(handler HandlerType) {
+	if handler == nil {
+		routes.MethodNotAllowed = nil
+	} else {
+		h := defaultBless(wrap(handler))
+		routes.MethodNotAllowed = http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
+			h(w, r, nil)
+		})
+	}
+}
+
 func defaultBless(k ContextHandler) httprouter.Handle {
 	return bless(k, &Context, defaultMW, &PanicHandler, &LogHandler)
 }
@@ -148,4 +160,5 @@ func Reset() {
 	defaultMW = newMiddlewares()
 	routes = httprouter.New()
 	NotFound(nil)
+	MethodNotAllowed(nil)
 }

--- a/kami_test.go
+++ b/kami_test.go
@@ -133,6 +133,36 @@ func TestNotFoundDefault(t *testing.T) {
 	expectResponseCode(t, "GET", "/missing/hello", http.StatusNotFound)
 }
 
+func TestMethodNotAllowed(t *testing.T) {
+	kami.Reset()
+	kami.Use("/test", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		return context.WithValue(ctx, "ok", true)
+	})
+	kami.Post("/test", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	})
+
+	kami.MethodNotAllowed(func (ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		ok, _ := ctx.Value("ok").(bool)
+		if !ok {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	expectResponseCode(t, "GET", "/test", http.StatusTeapot)
+}
+
+func TestMethodNotAllowedDefault(t *testing.T) {
+	kami.Reset()
+	kami.Post("/test", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	})
+
+	expectResponseCode(t, "GET", "/test", http.StatusMethodNotAllowed)
+}
+
 func noop(ctx context.Context, w http.ResponseWriter, r *http.Request) {}
 
 func expectResponseCode(t *testing.T, method, path string, expected int) {

--- a/kami_test.go
+++ b/kami_test.go
@@ -154,6 +154,24 @@ func TestMethodNotAllowed(t *testing.T) {
 	expectResponseCode(t, "GET", "/test", http.StatusTeapot)
 }
 
+func TestHandleMethodNotAllowed(t *testing.T) {
+	kami.Reset()
+	kami.Post("/test", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		panic("test panic")
+	})
+
+	// Handling enabled by default
+	expectResponseCode(t, "GET", "/test", http.StatusMethodNotAllowed)
+
+	// Not found deals with it when handling disabled
+	kami.HandleMethodNotAllowed(false)
+	expectResponseCode(t, "GET", "/test", http.StatusNotFound)
+
+	// And MethodNotAllowed status when handling enabled
+	kami.HandleMethodNotAllowed(true)
+	expectResponseCode(t, "GET", "/test", http.StatusMethodNotAllowed)
+}
+
 func TestMethodNotAllowedDefault(t *testing.T) {
 	kami.Reset()
 	kami.Post("/test", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {

--- a/mux.go
+++ b/mux.go
@@ -96,6 +96,18 @@ func (m *Mux) NotFound(handler HandlerType) {
 	})
 }
 
+// MethodNotAllowed registers special handler for invalid method requests (405).
+func (m *Mux) MethodNotAllowed(handler HandlerType) {
+	if handler == nil {
+		m.routes.MethodNotAllowed = nil
+	} else {
+		h := m.bless(wrap(handler))
+		m.routes.MethodNotAllowed = http.HandlerFunc(func (w http.ResponseWriter, r *http.Request) {
+			h(w, r, nil)
+		})
+	}
+}
+
 func (m *Mux) bless(k ContextHandler) httprouter.Handle {
 	return bless(k, &m.Context, m.middlewares, &m.PanicHandler, &m.LogHandler)
 }

--- a/mux.go
+++ b/mux.go
@@ -108,6 +108,11 @@ func (m *Mux) MethodNotAllowed(handler HandlerType) {
 	}
 }
 
+// Toggle any invalid method request handling in httprouter
+func (m *Mux) HandleMethodNotAllowed(value bool) {
+	m.routes.HandleMethodNotAllowed = value
+}
+
 func (m *Mux) bless(k ContextHandler) httprouter.Handle {
 	return bless(k, &m.Context, m.middlewares, &m.PanicHandler, &m.LogHandler)
 }

--- a/mux_test.go
+++ b/mux_test.go
@@ -115,4 +115,20 @@ func TestKamiMux(t *testing.T) {
 	if resp.Code != http.StatusTeapot {
 		t.Error("should return HTTP Teapot", resp.Code, "≠", http.StatusTeapot)
 	}
+
+	// test HandleMethodNotAllowed method
+	resp = httptest.NewRecorder()
+	req, err = http.NewRequest("GET", "/mux/method_not_allowed", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Reset NotFound handler to receive default 404 instead of custom handler 418(Teapot)
+	mux.NotFound(nil)
+
+	mux.HandleMethodNotAllowed(false)
+	stdMux.ServeHTTP(resp, req)
+	if resp.Code != http.StatusNotFound {
+		t.Error("should return HTTP NotFound", resp.Code, "≠", http.StatusNotFound)
+	}	
 }


### PR DESCRIPTION
HttpRouter allows to set custom `MethodNotAllowed` handler.
This patch provides corresponding methods for `kami` and `kami.Mux`.