### PR TITLE
"Afterware"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 ## kami [![GoDoc](https://godoc.org/github.com/guregu/kami?status.svg)](https://godoc.org/github.com/guregu/kami) [![Coverage](http://gocover.io/_badge/github.com/guregu/kami?0)](http://gocover.io/github.com/guregu/kami)
-`import "github.com/guregu/kami"`
+`import "github.com/guregu/kami"` [or](http://gopkg.in) `import "gopkg.in/guregu/kami.v1"`
 
-kami (神) is a tiny web framework using [x/net/context](https://blog.golang.org/context) for request context and [HttpRouter](https://github.com/julienschmidt/httprouter) for routing. It includes a simple system for running hierarchical middleware before requests, in addition to log and panic hooks. Graceful restart via einhorn is also supported.
+kami (神) is a tiny web framework using [x/net/context](https://blog.golang.org/context) for request context and [HttpRouter](https://github.com/julienschmidt/httprouter) for routing. It includes a simple system for running hierarchical middleware before and after requests, in addition to log and panic hooks. Graceful restart via einhorn is also supported.
 
-kami is designed to be used as central registration point for your routes, middleware, and context "god object". You are encouraged to use the global functions. However, kami now supports multiple muxes with `kami.New()`. 
+kami is designed to be used as central registration point for your routes, middleware, and context "god object". You are encouraged to use the global functions, but kami supports multiple muxes with `kami.New()`. 
 
 You are free to mount `kami.Handler()` wherever you wish, but a helpful `kami.Serve()` function is provided.
 
@@ -11,7 +11,12 @@ Here is a [presentation about the birth of kami](http://go-talks.appspot.com/git
 
 ### Example
 
+[Skip :fast_forward:](#usage)
+
+A contrived example using kami and x/net/context to localize greetings.
+
 ```go
+// Our webserver
 package main
 
 import (
@@ -20,28 +25,89 @@ import (
 
 	"github.com/guregu/kami"
 	"golang.org/x/net/context"
+
+	"github.com/my-github/greeting" // see package greeting below
 )
 
-func hello(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	fmt.Fprintf(w, "Hello, %s!", kami.Param(ctx, "name"))
+func greet(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	hello := greeting.FromContext(ctx)
+	name := kami.Param(ctx, "name")
+	fmt.Fprintf(w, "%s, %s!", hello, name)
 }
 
 func main() {
-	kami.Get("/hello/:name", hello)
-	kami.Serve()
+	ctx := context.Background()
+	ctx = greeting.WithContext(ctx, "Hello") // set default greeting
+	kami.Context = ctx                       // set our "god context", the base context for all requests
+
+	kami.Use("/hello/", greeting.Guess) // use this middleware for paths under /hello/
+	kami.Get("/hello/:name", greet)     // add a GET handler with a parameter in the URL
+	kami.Serve()                        // gracefully serve with support for einhorn and systemd
+}
+
+}
+```
+
+```go
+// Package greeting stores greeting settings in context.
+package greeting
+
+import (
+	"net/http"
+
+	"golang.org/x/net/context"
+	"golang.org/x/text/language"
+)
+
+// For more information about context and why we're doing this,
+// see https://blog.golang.org/context
+type ctxkey int
+
+var key ctxkey = 0
+
+var greetings = map[language.Tag]string{
+	language.AmericanEnglish: "Yo",
+	language.Japanese:        "こんにちは",
+}
+
+// Guess is kami middleware that examines Accept-Language and sets
+// the greeting to a better one if possible.
+func Guess(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+	if tag, _, err := language.ParseAcceptLanguage(r.Header.Get("Accept-Language")); err == nil {
+		for _, t := range tag {
+			if g, ok := greetings[t]; ok {
+				ctx = WithContext(ctx, g)
+				return ctx
+			}
+		}
+	}
+	return ctx
+}
+
+// WithContext returns a new context with the given greeting.
+func WithContext(ctx context.Context, greeting string) context.Context {
+	return context.WithValue(ctx, key, greeting)
+}
+
+// FromContext retrieves the greeting from this context,
+// or returns an empty string if missing.
+func FromContext(ctx context.Context) string {
+	hello, _ := ctx.Value(key).(string)
+	return hello
 }
 ```
 
 ### Usage
 
-* Set up routes using `kami.Get("path", handler)`, `kami.Post(...)`, etc. You can use [named parameters](https://github.com/julienschmidt/httprouter#named-parameters) or [wildcards](https://github.com/julienschmidt/httprouter#catch-all-parameters) in URLs like `/hello/:name/edit` or `/files/*path`, and access them using the context kami gives you: `kami.Param(ctx, "name")`. The following kinds of handlers are accepted:
+* Set up routes using `kami.Get("/path", handler)`, `kami.Post(...)`, etc. You can use [named parameters](https://github.com/julienschmidt/httprouter#named-parameters) or [wildcards](https://github.com/julienschmidt/httprouter#catch-all-parameters) in URLs like `/hello/:name/edit` or `/files/*path`, and access them using the context kami gives you: `kami.Param(ctx, "name")`. The following kinds of handlers are accepted:
   * types that implement `kami.ContextHandler`
   * `func(context.Context, http.ResponseWriter, *http.Request)`
   * types that implement `http.Handler`
   * `func(http.ResponseWriter, *http.Request)`
 * All contexts that kami uses are descended from `kami.Context`: this is the "god object" and the namesake of this project. By default, this is `context.Background()`, but feel free to replace it with a pre-initialized context suitable for your application.
 * Builds targeting Google App Engine will automatically wrap the "god object" Context with App Engine's per-request Context.
-* Add middleware with `kami.Use("path", kami.Middleware)`. More on middleware below.
+* Add middleware with `kami.Use("/path", kami.Middleware)`. Middleware runs before requests and can stop them early. More on middleware below.
+* Add afterware with `kami.After("/path", kami.Afterware)`. Afterware runs after requests.
 * You can provide a panic handler by setting `kami.PanicHandler`. When the panic handler is called, you can access the panic error with `kami.Exception(ctx)`. 
 * You can also provide a `kami.LogHandler` that will wrap every request. `kami.LogHandler` has a different function signature, taking a WriterProxy that has access to the response status code, etc.
 * Use `kami.Serve()` to gracefully serve your application, or mount `kami.Handler()` somewhere convenient. 
@@ -112,6 +178,32 @@ func main() {
 }
 ```
 
+#### Afterware
+
+```go
+type Afterware func(context.Context, mutil.WriterProxy, *http.Request) context.Context
+```
+
+```go
+func init() {
+	kami.After("/", cleanup)
+}
+```
+
+Running after the request handler, afterware is useful for cleaning up. Afterware is like a mirror image of middleware. Afterware also runs hierarchically, but in the reverse order of middleware. Wildcards are evaluated **before** hierarchical afterware.
+
+For example, a request for `/hello/greg` will run afterware registered under the following paths:
+
+1. `/hello/greg`
+2. `/hello/`
+3. `/`
+
+This gives afterware under specific paths the ability to use resources that may be closed by `/`. 
+
+Unlike middleware, afterware returning **nil** will not stop the remaining afterware from being evaluated. 
+
+`kami.After("/path", afterware)` supports many different types of functions, see the docs for `kami.AfterwareType` for more details. 
+
 ### Independent stacks with `*kami.Mux`
 
 kami was originally designed to be the "glue" between multiple packages in a complex web application. The global functions and `kami.Context` are an easy way for your packages to work together. However, if you would like to use kami as an embedded server within another app, serve two separate kami stacks on different ports, or otherwise would like to have an non-global version of kami, `kami.New()` may come in handy.
@@ -137,7 +229,7 @@ func init() {
 	mux.Context = adminContext
 	mux.Use("/", authorize)
 	mux.Get("/admin/memstats", memoryStats)
-	mux.Post("/admin/die", shutdown) // 😱
+	mux.Post("/admin/die", shutdown)
 	//  ...
 	http.Handle("/admin/", mux)
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -13,9 +13,10 @@ import (
 func BenchmarkStaticRoute(b *testing.B) {
 	kami.Reset()
 	kami.Get("/hello", noop)
+	req, _ := http.NewRequest("GET", "/hello", nil)
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/hello", nil)
 		kami.Handler().ServeHTTP(resp, req)
 		if resp.Code != http.StatusOK {
 			panic(resp.Code)
@@ -30,9 +31,10 @@ func BenchmarkParameter(b *testing.B) {
 	kami.Get("/hello/:name", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 		kami.Param(ctx, "name")
 	})
+	req, _ := http.NewRequest("GET", "/hello/bob", nil)
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/hello/bob", nil)
 		kami.Handler().ServeHTTP(resp, req)
 		if resp.Code != http.StatusOK {
 			panic(resp.Code)
@@ -47,9 +49,10 @@ func BenchmarkParameter5(b *testing.B) {
 			kami.Param(ctx, v)
 		}
 	})
+	req, _ := http.NewRequest("GET", "/a/b/c/d/e", nil)
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/a/b/c/d/e", nil)
 		kami.Handler().ServeHTTP(resp, req)
 		if resp.Code != http.StatusOK {
 			panic(resp.Code)
@@ -58,6 +61,9 @@ func BenchmarkParameter5(b *testing.B) {
 }
 
 // Middleware tests setting and using values with middleware
+// These test the speed of kami's middleware engine AND using
+// x/net/context to store values, so it could be a somewhat
+// realitic idea of what using kami would be like.
 
 func BenchmarkMiddleware(b *testing.B) {
 	kami.Reset()
@@ -69,9 +75,10 @@ func BenchmarkMiddleware(b *testing.B) {
 			w.WriteHeader(http.StatusServiceUnavailable)
 		}
 	})
+	req, _ := http.NewRequest("GET", "/test", nil)
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/test", nil)
 		kami.Handler().ServeHTTP(resp, req)
 		if resp.Code != http.StatusOK {
 			panic(resp.Code)
@@ -96,9 +103,100 @@ func BenchmarkMiddleware5(b *testing.B) {
 			}
 		}
 	})
+	req, _ := http.NewRequest("GET", "/test", nil)
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
-		req, _ := http.NewRequest("GET", "/test", nil)
+		kami.Handler().ServeHTTP(resp, req)
+		if resp.Code != http.StatusOK {
+			panic(resp.Code)
+		}
+	}
+}
+
+func BenchmarkMiddleware1Afterware1(b *testing.B) {
+	kami.Reset()
+	numbers := []int{1}
+	for _, n := range numbers {
+		n := n // wtf
+		kami.Use("/", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+			return context.WithValue(ctx, n, n)
+		})
+	}
+	kami.After("/", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		for _, n := range numbers {
+			if ctx.Value(n) != n {
+				panic(n)
+			}
+		}
+		return ctx
+	})
+	kami.Get("/test", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		// ...
+	})
+	req, _ := http.NewRequest("GET", "/test", nil)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		resp := httptest.NewRecorder()
+		kami.Handler().ServeHTTP(resp, req)
+		if resp.Code != http.StatusOK {
+			panic(resp.Code)
+		}
+	}
+}
+
+func BenchmarkMiddleware5Afterware1(b *testing.B) {
+	kami.Reset()
+	numbers := []int{1, 2, 3, 4, 5}
+	for _, n := range numbers {
+		n := n // wtf
+		kami.Use("/", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+			return context.WithValue(ctx, n, n)
+		})
+	}
+	kami.After("/", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		for _, n := range numbers {
+			if ctx.Value(n) != n {
+				panic(n)
+			}
+		}
+		return ctx
+	})
+	kami.Get("/test", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		for _, n := range numbers {
+			if ctx.Value(n) != n {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+		}
+	})
+	req, _ := http.NewRequest("GET", "/test", nil)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		resp := httptest.NewRecorder()
+		kami.Handler().ServeHTTP(resp, req)
+		if resp.Code != http.StatusOK {
+			panic(resp.Code)
+		}
+	}
+}
+
+// This tests just the URL walking middleware engine.
+func BenchmarkMiddlewareAfterwareMiss(b *testing.B) {
+	kami.Reset()
+	kami.Use("/dog/", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		return nil
+	})
+	kami.After("/dog/", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		return nil
+	})
+	kami.Get("/a/bbb/cc/d/e", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	req, _ := http.NewRequest("GET", "/a/bbb/cc/d/e", nil)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		resp := httptest.NewRecorder()
 		kami.Handler().ServeHTTP(resp, req)
 		if resp.Code != http.StatusOK {
 			panic(resp.Code)

--- a/bench_test.go
+++ b/bench_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/guregu/kami"
 )
 
-func BenchmarkStaticRoute(b *testing.B) {
+func BenchmarkShortRoute(b *testing.B) {
 	kami.Reset()
 	kami.Get("/hello", noop)
 	req, _ := http.NewRequest("GET", "/hello", nil)
@@ -18,9 +18,50 @@ func BenchmarkStaticRoute(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
 		kami.Handler().ServeHTTP(resp, req)
-		if resp.Code != http.StatusOK {
-			panic(resp.Code)
-		}
+	}
+}
+
+func BenchmarkLongRoute(b *testing.B) {
+	kami.Reset()
+	kami.Get("/aaaaaaaaaaaa/", noop)
+	req, _ := http.NewRequest("GET", "/aaaaaaaaaaaa/", nil)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		resp := httptest.NewRecorder()
+		kami.Handler().ServeHTTP(resp, req)
+	}
+}
+
+func BenchmarkDeepRoute(b *testing.B) {
+	kami.Reset()
+	kami.Get("/a/b/c/d/e/f/g", noop)
+	req, _ := http.NewRequest("GET", "/a/b/c/d/e/f/g", nil)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		resp := httptest.NewRecorder()
+		kami.Handler().ServeHTTP(resp, req)
+	}
+}
+
+func BenchmarkDeepRouteUnicode(b *testing.B) {
+	kami.Reset()
+	kami.Get("/ä/蜂/海/🐶/神/🍺/🍻", noop)
+	req, _ := http.NewRequest("GET", "/ä/蜂/海/🐶/神/🍺/🍻", nil)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		resp := httptest.NewRecorder()
+		kami.Handler().ServeHTTP(resp, req)
+	}
+}
+
+func BenchmarkSuperDeepRoute(b *testing.B) {
+	kami.Reset()
+	kami.Get("/a/b/c/d/e/f/g/h/i/l/k/l/m/n/o/p/q/r/hello world", noop)
+	req, _ := http.NewRequest("GET", "/a/b/c/d/e/f/g/h/i/l/k/l/m/n/o/p/q/r/hello world", nil)
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		resp := httptest.NewRecorder()
+		kami.Handler().ServeHTTP(resp, req)
 	}
 }
 
@@ -36,9 +77,6 @@ func BenchmarkParameter(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
 		kami.Handler().ServeHTTP(resp, req)
-		if resp.Code != http.StatusOK {
-			panic(resp.Code)
-		}
 	}
 }
 
@@ -54,9 +92,6 @@ func BenchmarkParameter5(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
 		kami.Handler().ServeHTTP(resp, req)
-		if resp.Code != http.StatusOK {
-			panic(resp.Code)
-		}
 	}
 }
 
@@ -80,9 +115,6 @@ func BenchmarkMiddleware(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
 		kami.Handler().ServeHTTP(resp, req)
-		if resp.Code != http.StatusOK {
-			panic(resp.Code)
-		}
 	}
 }
 
@@ -108,9 +140,6 @@ func BenchmarkMiddleware5(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
 		kami.Handler().ServeHTTP(resp, req)
-		if resp.Code != http.StatusOK {
-			panic(resp.Code)
-		}
 	}
 }
 
@@ -139,9 +168,6 @@ func BenchmarkMiddleware1Afterware1(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
 		kami.Handler().ServeHTTP(resp, req)
-		if resp.Code != http.StatusOK {
-			panic(resp.Code)
-		}
 	}
 }
 
@@ -175,9 +201,6 @@ func BenchmarkMiddleware5Afterware1(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
 		kami.Handler().ServeHTTP(resp, req)
-		if resp.Code != http.StatusOK {
-			panic(resp.Code)
-		}
 	}
 }
 
@@ -198,8 +221,5 @@ func BenchmarkMiddlewareAfterwareMiss(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
 		kami.Handler().ServeHTTP(resp, req)
-		if resp.Code != http.StatusOK {
-			panic(resp.Code)
-		}
 	}
 }

--- a/bench_test.go
+++ b/bench_test.go
@@ -10,59 +10,37 @@ import (
 	"github.com/guregu/kami"
 )
 
-func BenchmarkShortRoute(b *testing.B) {
+func routeBench(b *testing.B, route string) {
 	kami.Reset()
-	kami.Get("/hello", noop)
-	req, _ := http.NewRequest("GET", "/hello", nil)
+	kami.Use("/Z/", noopMW)
+	kami.After("/Z/", noopMW)
+	kami.Get(route, noop)
+	req, _ := http.NewRequest("GET", route, nil)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		resp := httptest.NewRecorder()
 		kami.Handler().ServeHTTP(resp, req)
 	}
+}
+
+func BenchmarkShortRoute(b *testing.B) {
+	routeBench(b, "/hello")
 }
 
 func BenchmarkLongRoute(b *testing.B) {
-	kami.Reset()
-	kami.Get("/aaaaaaaaaaaa/", noop)
-	req, _ := http.NewRequest("GET", "/aaaaaaaaaaaa/", nil)
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		resp := httptest.NewRecorder()
-		kami.Handler().ServeHTTP(resp, req)
-	}
+	routeBench(b, "/aaaaaaaaaaaa/")
 }
 
 func BenchmarkDeepRoute(b *testing.B) {
-	kami.Reset()
-	kami.Get("/a/b/c/d/e/f/g", noop)
-	req, _ := http.NewRequest("GET", "/a/b/c/d/e/f/g", nil)
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		resp := httptest.NewRecorder()
-		kami.Handler().ServeHTTP(resp, req)
-	}
+	routeBench(b, "/a/b/c/d/e/f/g")
 }
 
 func BenchmarkDeepRouteUnicode(b *testing.B) {
-	kami.Reset()
-	kami.Get("/ä/蜂/海/🐶/神/🍺/🍻", noop)
-	req, _ := http.NewRequest("GET", "/ä/蜂/海/🐶/神/🍺/🍻", nil)
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		resp := httptest.NewRecorder()
-		kami.Handler().ServeHTTP(resp, req)
-	}
+	routeBench(b, "/ä/蜂/海/🐶/神/🍺/🍻")
 }
 
 func BenchmarkSuperDeepRoute(b *testing.B) {
-	kami.Reset()
-	kami.Get("/a/b/c/d/e/f/g/h/i/l/k/l/m/n/o/p/q/r/hello world", noop)
-	req, _ := http.NewRequest("GET", "/a/b/c/d/e/f/g/h/i/l/k/l/m/n/o/p/q/r/hello world", nil)
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		resp := httptest.NewRecorder()
-		kami.Handler().ServeHTTP(resp, req)
-	}
+	routeBench(b, "/a/b/c/d/e/f/g/h/i/l/k/l/m/n/o/p/q/r/hello world")
 }
 
 // Param benchmarks test accessing URL params

--- a/kami.go
+++ b/kami.go
@@ -130,7 +130,7 @@ func bless(k ContextHandler, base *context.Context, m *middlewares, panicHandler
 
 		writer := w
 		var proxy mutil.WriterProxy
-		if *logHandler != nil {
+		if *logHandler != nil || m.after != nil || m.afterWildcards != nil {
 			proxy = mutil.WrapWriter(w)
 			writer = proxy
 		}
@@ -153,6 +153,9 @@ func bless(k ContextHandler, base *context.Context, m *middlewares, panicHandler
 		ctx, ok := m.run(ctx, writer, r)
 		if ok {
 			k.ServeHTTPContext(ctx, writer, r)
+		}
+		if proxy != nil {
+			ctx = m.after(ctx, proxy, r)
 		}
 
 		if *logHandler != nil {

--- a/kami.go
+++ b/kami.go
@@ -120,7 +120,7 @@ func defaultBless(k ContextHandler) httprouter.Handle {
 // bless is the meat of kami.
 // It wraps a ContextHandler into an httprouter compatible request,
 // in order to run all the middleware and other special handlers.
-func bless(k ContextHandler, base *context.Context, m *wares, panicHandler *HandlerType, logHandler *func(context.Context, mutil.WriterProxy, *http.Request)) httprouter.Handle {
+func bless(h ContextHandler, base *context.Context, mw *wares, panicHandler *HandlerType, logHandler *func(context.Context, mutil.WriterProxy, *http.Request)) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 		ctx := defaultContext(*base, r)
 		if len(params) > 0 {
@@ -128,18 +128,17 @@ func bless(k ContextHandler, base *context.Context, m *wares, panicHandler *Hand
 		}
 		ranLogHandler := false // track this in case the log handler blows up
 
-		writer := w
 		var proxy mutil.WriterProxy
-		if *logHandler != nil || m.after != nil || m.afterWildcards != nil {
+		if *logHandler != nil || mw.needsWrapper() {
 			proxy = mutil.WrapWriter(w)
-			writer = proxy
+			w = proxy
 		}
 
 		if *panicHandler != nil {
 			defer func() {
 				if err := recover(); err != nil {
 					ctx = newContextWithException(ctx, err)
-					wrap(*panicHandler).ServeHTTPContext(ctx, writer, r)
+					wrap(*panicHandler).ServeHTTPContext(ctx, w, r)
 
 					if *logHandler != nil && !ranLogHandler {
 						(*logHandler)(ctx, proxy, r)
@@ -150,12 +149,12 @@ func bless(k ContextHandler, base *context.Context, m *wares, panicHandler *Hand
 			}()
 		}
 
-		ctx, ok := m.run(ctx, writer, r)
+		ctx, ok := mw.run(ctx, w, r)
 		if ok {
-			k.ServeHTTPContext(ctx, writer, r)
+			h.ServeHTTPContext(ctx, w, r)
 		}
 		if proxy != nil {
-			ctx = m.after(ctx, proxy, r)
+			ctx = mw.after(ctx, proxy, r)
 		}
 
 		if *logHandler != nil {

--- a/kami.go
+++ b/kami.go
@@ -120,7 +120,7 @@ func defaultBless(k ContextHandler) httprouter.Handle {
 // bless is the meat of kami.
 // It wraps a ContextHandler into an httprouter compatible request,
 // in order to run all the middleware and other special handlers.
-func bless(k ContextHandler, base *context.Context, m *middlewares, panicHandler *HandlerType, logHandler *func(context.Context, mutil.WriterProxy, *http.Request)) httprouter.Handle {
+func bless(k ContextHandler, base *context.Context, m *wares, panicHandler *HandlerType, logHandler *func(context.Context, mutil.WriterProxy, *http.Request)) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 		ctx := defaultContext(*base, r)
 		if len(params) > 0 {
@@ -173,7 +173,7 @@ func Reset() {
 	Context = context.Background()
 	PanicHandler = nil
 	LogHandler = nil
-	defaultMW = newMiddlewares()
+	defaultMW = newWares()
 	routes = httprouter.New()
 	NotFound(nil)
 	MethodNotAllowed(nil)

--- a/kami_test.go
+++ b/kami_test.go
@@ -224,6 +224,10 @@ func TestMethodNotAllowedDefault(t *testing.T) {
 
 func noop(ctx context.Context, w http.ResponseWriter, r *http.Request) {}
 
+func noopMW(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+	return ctx
+}
+
 func expectResponseCode(t *testing.T, method, path string, expected int) {
 	resp := httptest.NewRecorder()
 	req, err := http.NewRequest(method, path, nil)

--- a/kami_test.go
+++ b/kami_test.go
@@ -1,8 +1,6 @@
 package kami_test
 
 import (
-	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,46 +13,90 @@ import (
 
 func TestKami(t *testing.T) {
 	kami.Reset()
+
+	expect := func(ctx context.Context, i int) context.Context {
+		if prev := ctx.Value(i - 1).(int); prev != i-1 {
+			t.Error("missing", i)
+		}
+		return context.WithValue(ctx, i, i)
+	}
+
 	kami.Use("/", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
-		return context.WithValue(ctx, "test1", "1")
+		ctx = context.WithValue(ctx, 1, 1)
+		ctx = context.WithValue(ctx, "handler", new(bool))
+		ctx = context.WithValue(ctx, "done", new(bool))
+		ctx = context.WithValue(ctx, "recovered", new(bool))
+		return ctx
 	})
-	kami.Use("/v2/", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
-		return context.WithValue(ctx, "test2", "2")
+	kami.Use("/a/", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		ctx = expect(ctx, 2)
+		return ctx
 	})
-	kami.Get("/v2/papers/:page", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-		page := kami.Param(ctx, "page")
-		if page == "" {
-			panic("blank page")
+	kami.Use("/a/", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		ctx = expect(ctx, 3)
+		return ctx
+	})
+	kami.Use("/a/b", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		ctx = expect(ctx, 4)
+		return ctx
+	})
+	kami.Use("/a/*files", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		ctx = expect(ctx, 5)
+		return ctx
+	})
+	kami.Get("/a/b", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		if prev := ctx.Value(5).(int); prev != 5 {
+			t.Error("handler: missing", 5)
 		}
-		io.WriteString(w, page)
+		*(ctx.Value("handler").(*bool)) = true
 
-		test1 := ctx.Value("test1").(string)
-		test2 := ctx.Value("test2").(string)
-
-		if test1 != "1" || test2 != "2" {
-			t.Error("unexpected ctx value:", test1, test2)
-		}
+		w.WriteHeader(http.StatusTeapot)
 	})
+	kami.After("/a/*files", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		ctx = expect(ctx, 6)
+		if !*(ctx.Value("handler").(*bool)) {
+			t.Error("ran before handler")
+		}
+		return ctx
+	})
+	kami.After("/a/b", kami.Afterware(func(ctx context.Context, w mutil.WriterProxy, r *http.Request) context.Context {
+		ctx = expect(ctx, 7)
+		return ctx
+	}))
+	kami.After("/a/", func(ctx context.Context) context.Context {
+		ctx = expect(ctx, 9)
+		return ctx
+	})
+	kami.After("/a/", func(ctx context.Context) context.Context {
+		ctx = expect(ctx, 8)
+		return ctx
+	})
+	kami.After("/", func(ctx context.Context, w mutil.WriterProxy, r *http.Request) context.Context {
+		if status := w.Status(); status != http.StatusTeapot {
+			t.Error("wrong status", status)
+		}
 
-	resp := httptest.NewRecorder()
-	req, err := http.NewRequest("GET", "/v2/papers/3", nil)
-	if err != nil {
-		t.Fatal(err)
+		ctx = expect(ctx, 9)
+		*(ctx.Value("done").(*bool)) = true
+		panic("🍣")
+		return nil
+	})
+	kami.PanicHandler = func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		if got := kami.Exception(ctx); got.(string) != "🍣" {
+			t.Error("panic handler: expected sushi, got", got)
+		}
+		if !*(ctx.Value("done").(*bool)) {
+			t.Error("didn't finish")
+		}
+		*(ctx.Value("recovered").(*bool)) = true
+	}
+	kami.LogHandler = func(ctx context.Context, w mutil.WriterProxy, r *http.Request) {
+		if !*(ctx.Value("recovered").(*bool)) {
+			t.Error("didn't recover")
+		}
 	}
 
-	kami.Handler().ServeHTTP(resp, req)
-	if resp.Code != http.StatusOK {
-		t.Error("should return HTTP OK", resp.Code, "≠", http.StatusOK)
-	}
-
-	data, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		panic(err)
-	}
-
-	if string(data) != "3" {
-		t.Error("expected page 3, got", string(data))
-	}
+	expectResponseCode(t, "GET", "/a/b", http.StatusTeapot)
 }
 
 func TestLoggerAndPanic(t *testing.T) {
@@ -103,11 +145,10 @@ func TestPanickingLogger(t *testing.T) {
 			t.Error("unexpected exception:", err)
 		}
 		w.WriteHeader(http.StatusServiceUnavailable)
-		w.Write([]byte("error 503"))
 	})
-	kami.Post("/test", noop)
+	kami.Options("/test", noop)
 
-	expectResponseCode(t, "POST", "/test", http.StatusServiceUnavailable)
+	expectResponseCode(t, "OPTIONS", "/test", http.StatusServiceUnavailable)
 }
 
 func TestNotFound(t *testing.T) {

--- a/mux.go
+++ b/mux.go
@@ -20,16 +20,16 @@ type Mux struct {
 	LogHandler func(context.Context, mutil.WriterProxy, *http.Request)
 
 	routes *httprouter.Router
-	*middlewares
+	*wares
 }
 
 // New creates a new independent kami router and middleware stack.
 // It is totally separate from the global kami.Context and middleware stack.
 func New() *Mux {
 	m := &Mux{
-		Context:     context.Background(),
-		routes:      httprouter.New(),
-		middlewares: newMiddlewares(),
+		Context: context.Background(),
+		routes:  httprouter.New(),
+		wares:   newWares(),
 	}
 	m.NotFound(nil)
 	m.MethodNotAllowed(nil)
@@ -124,5 +124,5 @@ func (m *Mux) EnableMethodNotAllowed(enabled bool) {
 }
 
 func (m *Mux) bless(k ContextHandler) httprouter.Handle {
-	return bless(k, &m.Context, m.middlewares, &m.PanicHandler, &m.LogHandler)
+	return bless(k, &m.Context, m.wares, &m.PanicHandler, &m.LogHandler)
 }


### PR DESCRIPTION
Afterware: it's like middleware but runs after the request, in reverse hierarchical order. 

It would be useful to run something like middleware after a request, to clean up connections to things, etc.

For the path `/test/123`, this would make our execution model like so:

1. Middleware: `/`
2. Middleware: `/test/`
3. Middleware: `/test/123`
4. Wildcard middleware
5. The request handler
6. Wildcard afterware
7. Afterware: `/test/123`
8. Afterware: `/test/`
9. Afterware: `/`
10. LogHandler

Running afterware backwards like this would give afterware that depends on resources closed by afterware `/` a chance.

I dub it the kami Pyramid of Execution. 

#### TODO:
- [x] Implementation 
- [x] Tests
- [x] Docs