### PR TITLE
CancelOnClose 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## kami [![GoDoc](https://godoc.org/github.com/guregu/kami?status.svg)](https://godoc.org/github.com/guregu/kami) [![Coverage](http://gocover.io/_badge/github.com/guregu/kami?0)](http://gocover.io/github.com/guregu/kami)
+## kami [![GoDoc](https://godoc.org/github.com/guregu/kami?status.svg)](https://godoc.org/github.com/guregu/kami) [![Coverage](http://gocover.io/_badge/github.com/guregu/kami)](http://gocover.io/github.com/guregu/kami)
 `import "github.com/guregu/kami"` [or](http://gopkg.in) `import "gopkg.in/guregu/kami.v1"`
 
 kami (神) is a tiny web framework using [x/net/context](https://blog.golang.org/context) for request context and [HttpRouter](https://github.com/julienschmidt/httprouter) for routing. It includes a simple system for running hierarchical middleware before and after requests, in addition to log and panic hooks. Graceful restart via einhorn is also supported.
@@ -201,6 +201,13 @@ This gives afterware under specific paths the ability to use resources that may 
 Unlike middleware, afterware returning **nil** will not stop the remaining afterware from being evaluated. 
 
 `kami.After("/path", afterware)` supports many different types of functions, see the docs for `kami.AfterwareType` for more details. 
+
+#### Automatic cancellation
+```go
+kami.CancelOnClose = true 
+```
+
+By setting `kami.CancelOnClose` (or its `*kami.Mux` equivalent) to **true**, a request's context will automatically be cancelled if its connection is closed. Check out [the docs for Context](https://godoc.org/golang.org/x/net/context#Context) on how to use `ctx.Done()` and [this article](https://blog.golang.org/pipelines) for more information on pipeline pattern. 
 
 ### Independent stacks with `*kami.Mux`
 

--- a/kami.go
+++ b/kami.go
@@ -11,6 +11,9 @@ import (
 var (
 	// Context is the root "god object" from which every request's context will derive.
 	Context = context.Background()
+	// CancelOnClose decides whether to cancel a request's context automatically
+	// if the request's connection is closed.
+	CancelOnClose = false
 
 	// PanicHandler will, if set, be called on panics.
 	// You can use kami.Exception(ctx) within the panic handler to get panic details.
@@ -114,31 +117,35 @@ func EnableMethodNotAllowed(enabled bool) {
 }
 
 func defaultBless(k ContextHandler) httprouter.Handle {
-	return bless(k, &Context, defaultMW, &PanicHandler, &LogHandler)
+	return bless(k, &Context, defaultMW, &PanicHandler, &LogHandler, &CancelOnClose)
 }
 
 // bless is the meat of kami.
 // It wraps a ContextHandler into an httprouter compatible request,
 // in order to run all the middleware and other special handlers.
-func bless(h ContextHandler, base *context.Context, mw *wares, panicHandler *HandlerType, logHandler *func(context.Context, mutil.WriterProxy, *http.Request)) httprouter.Handle {
+func bless(h ContextHandler, base *context.Context, mw *wares, panicHandler *HandlerType, logHandler *func(context.Context, mutil.WriterProxy, *http.Request), cancelOnClose *bool) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
-		ctx, cancel := context.WithCancel(defaultContext(*base, r))
-		defer cancel()
+		ctx := defaultContext(*base, r)
+		if *cancelOnClose {
+			var cancel func()
+			ctx, cancel = context.WithCancel(ctx)
+			defer cancel()
+
+			// cancel our context if connection is closed
+			if closeNotifier, ok := w.(http.CloseNotifier); ok {
+				go func() {
+					select {
+					case <-ctx.Done():
+					case <-closeNotifier.CloseNotify():
+						cancel()
+					}
+				}()
+			}
+		}
 		if len(params) > 0 {
 			ctx = newContextWithParams(ctx, params)
 		}
 		ranLogHandler := false // track this in case the log handler blows up
-
-		// cancel our context if connection is closed
-		if closeNotifier, ok := w.(http.CloseNotifier); ok {
-			go func() {
-				select {
-				case <-ctx.Done():
-				case <-closeNotifier.CloseNotify():
-					cancel()
-				}
-			}()
-		}
 
 		var proxy mutil.WriterProxy
 		if *logHandler != nil || mw.needsWrapper() {

--- a/kami.go
+++ b/kami.go
@@ -189,6 +189,7 @@ func bless(h ContextHandler, base *context.Context, mw *wares, panicHandler *Han
 // It removes every handler and all middleware.
 func Reset() {
 	Context = context.Background()
+	CancelOnClose = false
 	PanicHandler = nil
 	LogHandler = nil
 	defaultMW = newWares()

--- a/mux.go
+++ b/mux.go
@@ -13,6 +13,9 @@ type Mux struct {
 	// Context is the root "god object" for this mux,
 	// from which every request's context will derive.
 	Context context.Context
+	// CancelOnClose decides whether to cancel a request's context automatically
+	// if the request's connection is closed. Default value is false.
+	CancelOnClose bool
 	// PanicHandler will, if set, be called on panics.
 	// You can use kami.Exception(ctx) within the panic handler to get panic details.
 	PanicHandler HandlerType
@@ -124,5 +127,5 @@ func (m *Mux) EnableMethodNotAllowed(enabled bool) {
 }
 
 func (m *Mux) bless(k ContextHandler) httprouter.Handle {
-	return bless(k, &m.Context, m.wares, &m.PanicHandler, &m.LogHandler)
+	return bless(k, &m.Context, m.wares, &m.PanicHandler, &m.LogHandler, &m.CancelOnClose)
 }


### PR DESCRIPTION
Adds the `CancelOnClose` option to kami and mux. When set to true, a request's context will be cancelled if its connection is closed. 
This is false by default to avoid breaking any pre-existing code. 

I should probably add some new tests, but this works.  