### PR TITLE
Allow registration of multiple wildcard middlewares

### DIFF
--- a/kami_17_test.go
+++ b/kami_17_test.go
@@ -59,51 +59,64 @@ func TestKami(t *testing.T) {
 		ctx = expect(ctx, 5)
 		return ctx
 	})
+	kami.Use("/a/*files", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		expectEqual(ctx, r.Context(), 6)
+		ctx = expect(ctx, 6)
+		return ctx
+	})
 	kami.Get("/a/b", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-		expectEqual(ctx, r.Context(), 5)
-		if prev := ctx.Value(5).(int); prev != 5 {
-			t.Error("handler: missing", 5)
+		expectEqual(ctx, r.Context(), 6)
+		if prev := ctx.Value(6).(int); prev != 6 {
+			t.Error("handler: missing", 6)
 		}
 		*(ctx.Value("handler").(*bool)) = true
 
 		w.WriteHeader(http.StatusTeapot)
 	})
 	kami.After("/a/*files", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
-		expectEqual(ctx, r.Context(), 6)
-		ctx = expect(ctx, 6)
+		expectEqual(ctx, r.Context(), 8)
+		ctx = expect(ctx, 8)
+		if !*(ctx.Value("handler").(*bool)) {
+			t.Error("ran before handler")
+		}
+		return ctx
+	})
+	kami.After("/a/*files", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		expectEqual(ctx, r.Context(), 7)
+		ctx = expect(ctx, 7)
 		if !*(ctx.Value("handler").(*bool)) {
 			t.Error("ran before handler")
 		}
 		return ctx
 	})
 	kami.After("/a/b", kami.Afterware(func(ctx context.Context, w mutil.WriterProxy, r *http.Request) context.Context {
-		expectEqual(ctx, r.Context(), 7)
-		ctx = expect(ctx, 7)
-		return ctx
-	}))
-	kami.After("/a/", func(ctx context.Context, w mutil.WriterProxy, r *http.Request) context.Context {
 		expectEqual(ctx, r.Context(), 9)
 		ctx = expect(ctx, 9)
 		return ctx
+	}))
+	kami.After("/a/", func(ctx context.Context, w mutil.WriterProxy, r *http.Request) context.Context {
+		expectEqual(ctx, r.Context(), 11)
+		ctx = expect(ctx, 11)
+		return ctx
 	})
 	kami.After("/a/", func(ctx context.Context, w mutil.WriterProxy, r *http.Request) context.Context {
-		expectEqual(ctx, r.Context(), 8)
-		ctx = expect(ctx, 8)
+		expectEqual(ctx, r.Context(), 10)
+		ctx = expect(ctx, 10)
 		return ctx
 	})
 	kami.After("/", func(ctx context.Context, w mutil.WriterProxy, r *http.Request) context.Context {
-		expectEqual(ctx, r.Context(), 10)
+		expectEqual(ctx, r.Context(), 12)
 		if status := w.Status(); status != http.StatusTeapot {
 			t.Error("wrong status", status)
 		}
 
-		ctx = expect(ctx, 10)
+		ctx = expect(ctx, 12)
 		*(ctx.Value("done").(*bool)) = true
 		panic("🍣")
 		return nil
 	})
 	kami.PanicHandler = func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-		expectEqual(ctx, r.Context(), 11)
+		expectEqual(ctx, r.Context(), 13)
 		if got := kami.Exception(ctx); got.(string) != "🍣" {
 			t.Error("panic handler: expected sushi, got", got)
 		}
@@ -113,7 +126,7 @@ func TestKami(t *testing.T) {
 		*(ctx.Value("recovered").(*bool)) = true
 	}
 	kami.LogHandler = func(ctx context.Context, w mutil.WriterProxy, r *http.Request) {
-		expectEqual(ctx, r.Context(), 12)
+		expectEqual(ctx, r.Context(), 14)
 		if !*(ctx.Value("recovered").(*bool)) {
 			t.Error("didn't recover")
 		}

--- a/kami_old_test.go
+++ b/kami_old_test.go
@@ -49,31 +49,42 @@ func TestKami(t *testing.T) {
 		ctx = expect(ctx, 5)
 		return ctx
 	})
+	kami.Use("/a/*files", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		ctx = expect(ctx, 6)
+		return ctx
+	})
 	kami.Get("/a/b", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-		if prev := ctx.Value(5).(int); prev != 5 {
-			t.Error("handler: missing", 5)
+		if prev := ctx.Value(6).(int); prev != 6 {
+			t.Error("handler: missing", 6)
 		}
 		*(ctx.Value("handler").(*bool)) = true
 
 		w.WriteHeader(http.StatusTeapot)
 	})
 	kami.After("/a/*files", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
-		ctx = expect(ctx, 6)
+		ctx = expect(ctx, 8)
+		if !*(ctx.Value("handler").(*bool)) {
+			t.Error("ran before handler")
+		}
+		return ctx
+	})
+	kami.After("/a/*files", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
+		ctx = expect(ctx, 7)
 		if !*(ctx.Value("handler").(*bool)) {
 			t.Error("ran before handler")
 		}
 		return ctx
 	})
 	kami.After("/a/b", kami.Afterware(func(ctx context.Context, w mutil.WriterProxy, r *http.Request) context.Context {
-		ctx = expect(ctx, 7)
-		return ctx
-	}))
-	kami.After("/a/", func(ctx context.Context) context.Context {
 		ctx = expect(ctx, 9)
 		return ctx
+	}))
+	kami.After("/a/", func(ctx context.Context, w mutil.WriterProxy, r *http.Request) context.Context {
+		ctx = expect(ctx, 11)
+		return ctx
 	})
-	kami.After("/a/", func(ctx context.Context) context.Context {
-		ctx = expect(ctx, 8)
+	kami.After("/a/", func(ctx context.Context, w mutil.WriterProxy, r *http.Request) context.Context {
+		ctx = expect(ctx, 10)
 		return ctx
 	})
 	kami.After("/", func(ctx context.Context, w mutil.WriterProxy, r *http.Request) context.Context {
@@ -81,7 +92,7 @@ func TestKami(t *testing.T) {
 			t.Error("wrong status", status)
 		}
 
-		ctx = expect(ctx, 10)
+		ctx = expect(ctx, 12)
 		*(ctx.Value("done").(*bool)) = true
 		panic("🍣")
 		return nil

--- a/middleware_old.go
+++ b/middleware_old.go
@@ -20,10 +20,10 @@ type Middleware func(context.Context, http.ResponseWriter, *http.Request) contex
 // kami will try its best to convert standard, non-context middleware.
 // See the Use function for important information about how kami middleware is run.
 // The following concrete types are accepted:
-// 	- Middleware
-// 	- func(context.Context, http.ResponseWriter, *http.Request) context.Context
-// 	- func(http.Handler) http.Handler               [* see Use docs]
-// 	- func(http.ContextHandler) http.ContextHandler [* see Use docs]
+//  - Middleware
+//  - func(context.Context, http.ResponseWriter, *http.Request) context.Context
+//  - func(http.Handler) http.Handler               [* see Use docs]
+//  - func(http.ContextHandler) http.ContextHandler [* see Use docs]
 type MiddlewareType interface{}
 
 // Afterware is a function that will run after middleware and the request.
@@ -67,13 +67,15 @@ func (m *wares) run(ctx context.Context, w http.ResponseWriter, r *http.Request)
 	if m.wildcards != nil {
 		// wildcard middleware
 		if wild, params := m.wildcards.Get(r.URL.Path); wild != nil {
-			if mw, ok := wild.(Middleware); ok {
+			if mws, ok := wild.(*[]Middleware); ok {
 				ctx = mergeParams(ctx, params)
-				result := mw(ctx, w, r)
-				if result == nil {
-					return ctx, false
+				for _, mw := range *mws {
+					result := mw(ctx, w, r)
+					if result == nil {
+						return ctx, false
+					}
+					ctx = result
 				}
-				ctx = result
 			}
 		}
 	}
@@ -87,11 +89,13 @@ func (m *wares) after(ctx context.Context, w mutil.WriterProxy, r *http.Request)
 	if m.afterWildcards != nil {
 		// wildcard afterware
 		if wild, params := m.afterWildcards.Get(r.URL.Path); wild != nil {
-			if aw, ok := wild.(Afterware); ok {
+			if aws, ok := wild.(*[]Afterware); ok {
 				ctx = mergeParams(ctx, params)
-				result := aw(ctx, w, r)
-				if result != nil {
-					ctx = result
+				for _, aw := range *aws {
+					result := aw(ctx, w, r)
+					if result != nil {
+						ctx = result
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Addresses part of #23 
Now you can register more than one wildcard middleware/afterware per path. 