### PR TITLE
Option to cancel all request contexts automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ func FromContext(ctx context.Context) string {
 * Builds targeting Google App Engine will automatically wrap the "god object" Context with App Engine's per-request Context.
 * Add middleware with `kami.Use("/path", kami.Middleware)`. Middleware runs before requests and can stop them early. More on middleware below.
 * Add afterware with `kami.After("/path", kami.Afterware)`. Afterware runs after requests.
+* Set `kami.Cancel` to `true` to automatically cancel all request's contexts after the request is finished. Unlike the standard library, kami does not cancel contexts by default.
 * You can provide a panic handler by setting `kami.PanicHandler`. When the panic handler is called, you can access the panic error with `kami.Exception(ctx)`. 
 * You can also provide a `kami.LogHandler` that will wrap every request. `kami.LogHandler` has a different function signature, taking a WriterProxy that has access to the response status code, etc.
 * Use `kami.Serve()` to gracefully serve your application, or mount `kami.Handler()` somewhere convenient. 

--- a/globalmux_17.go
+++ b/globalmux_17.go
@@ -13,6 +13,8 @@ import (
 var (
 	// Context is the root "god object" from which every request's context will derive.
 	Context = context.Background()
+	// Cancel will, if true, automatically cancel the context of incoming requests after they finish.
+	Cancel bool
 
 	// PanicHandler will, if set, be called on panics.
 	// You can use kami.Exception(ctx) within the panic handler to get panic details.
@@ -65,6 +67,7 @@ func bless(h ContextHandler) httptreemux.HandlerFunc {
 	k := kami{
 		handler:      h,
 		base:         &Context,
+		autocancel:   &Cancel,
 		middleware:   defaultMW,
 		panicHandler: &PanicHandler,
 		logHandler:   &LogHandler,
@@ -76,6 +79,7 @@ func bless(h ContextHandler) httptreemux.HandlerFunc {
 // It removes every handler and all middleware.
 func Reset() {
 	Context = context.Background()
+	Cancel = false
 	PanicHandler = nil
 	LogHandler = nil
 	defaultMW = newWares()

--- a/globalmux_old.go
+++ b/globalmux_old.go
@@ -13,6 +13,8 @@ import (
 var (
 	// Context is the root "god object" from which every request's context will derive.
 	Context = context.Background()
+	// Cancel will, if true, automatically cancel the context of incoming requests after they finish.
+	Cancel bool
 
 	// PanicHandler will, if set, be called on panics.
 	// You can use kami.Exception(ctx) within the panic handler to get panic details.
@@ -65,6 +67,7 @@ func bless(h ContextHandler) httptreemux.HandlerFunc {
 	k := kami{
 		handler:      h,
 		base:         &Context,
+		autocancel:   &Cancel,
 		middleware:   defaultMW,
 		panicHandler: &PanicHandler,
 		logHandler:   &LogHandler,
@@ -76,6 +79,7 @@ func bless(h ContextHandler) httptreemux.HandlerFunc {
 // It removes every handler and all middleware.
 func Reset() {
 	Context = context.Background()
+	Cancel = false
 	PanicHandler = nil
 	LogHandler = nil
 	defaultMW = newWares()

--- a/kami_17.go
+++ b/kami_17.go
@@ -14,6 +14,7 @@ import (
 // in order to run all the middleware and other special handlers.
 type kami struct {
 	handler      ContextHandler
+	autocancel   *bool
 	base         *context.Context
 	middleware   *wares
 	panicHandler *HandlerType
@@ -23,6 +24,7 @@ type kami struct {
 func (k kami) handle(w http.ResponseWriter, r *http.Request, params map[string]string) {
 	var (
 		ctx           = defaultContext(*k.base, r)
+		autocancel    = *k.autocancel
 		handler       = k.handler
 		mw            = *k.middleware
 		panicHandler  = *k.panicHandler
@@ -31,6 +33,12 @@ func (k kami) handle(w http.ResponseWriter, r *http.Request, params map[string]s
 	)
 	if len(params) > 0 {
 		ctx = newContextWithParams(ctx, params)
+	}
+
+	if autocancel {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithCancel(ctx)
+		defer cancel()
 	}
 
 	if ctx != context.Background() {

--- a/kami_17_test.go
+++ b/kami_17_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/zenazn/goji/web/mutil"
 
@@ -15,6 +16,9 @@ import (
 
 func TestKami(t *testing.T) {
 	kami.Reset()
+	kami.Cancel = true
+
+	done := make(chan struct{})
 
 	expect := func(ctx context.Context, i int) context.Context {
 		if prev := ctx.Value(i - 1).(int); prev != i-1 {
@@ -37,6 +41,10 @@ func TestKami(t *testing.T) {
 		ctx = context.WithValue(ctx, "handler", new(bool))
 		ctx = context.WithValue(ctx, "done", new(bool))
 		ctx = context.WithValue(ctx, "recovered", new(bool))
+		go func() {
+			<-ctx.Done()
+			close(done)
+		}()
 		return ctx
 	})
 	kami.Use("/a/", func(ctx context.Context, w http.ResponseWriter, r *http.Request) context.Context {
@@ -133,6 +141,12 @@ func TestKami(t *testing.T) {
 	}
 
 	expectResponseCode(t, "GET", "/a/b", http.StatusTeapot)
+	select {
+	case <-done:
+		// ok
+	case <-time.After(10 * time.Second):
+		panic("didn't cancel")
+	}
 }
 
 func TestLoggerAndPanic(t *testing.T) {

--- a/mux.go
+++ b/mux.go
@@ -15,6 +15,8 @@ type Mux struct {
 	// Context is the root "god object" for this mux,
 	// from which every request's context will derive.
 	Context context.Context
+	// Cancel will, if true, automatically cancel the context of incoming requests after they finish.
+	Cancel bool
 	// PanicHandler will, if set, be called on panics.
 	// You can use kami.Exception(ctx) within the panic handler to get panic details.
 	PanicHandler HandlerType
@@ -136,6 +138,7 @@ func (m *Mux) bless(h ContextHandler) httptreemux.HandlerFunc {
 	k := kami{
 		handler:      h,
 		base:         &m.Context,
+		autocancel:   &m.Cancel,
 		middleware:   m.wares,
 		panicHandler: &m.PanicHandler,
 		logHandler:   &m.LogHandler,

--- a/mux_17.go
+++ b/mux_17.go
@@ -15,6 +15,8 @@ type Mux struct {
 	// Context is the root "god object" for this mux,
 	// from which every request's context will derive.
 	Context context.Context
+	// Cancel will, if true, automatically cancel the context of incoming requests after they finish.
+	Cancel bool
 	// PanicHandler will, if set, be called on panics.
 	// You can use kami.Exception(ctx) within the panic handler to get panic details.
 	PanicHandler HandlerType
@@ -136,6 +138,7 @@ func (m *Mux) bless(h ContextHandler) httptreemux.HandlerFunc {
 	k := kami{
 		handler:      h,
 		base:         &m.Context,
+		autocancel:   &m.Cancel,
 		middleware:   m.wares,
 		panicHandler: &m.PanicHandler,
 		logHandler:   &m.LogHandler,


### PR DESCRIPTION
Set `kami.Cancel` or `mux.Cancel` to true to get behavior like the standard library (automatically cancel requests when they are done serving). 