### PR TITLE
Support  AppEngine Flexible environments with the Go 1.7 changes

### DIFF
--- a/defaults.go
+++ b/defaults.go
@@ -1,4 +1,4 @@
-// +build !appengine
+// +build !appengine,!appenginevm
 
 package kami
 

--- a/defaults_appengine.go
+++ b/defaults_appengine.go
@@ -1,4 +1,4 @@
-// +build appengine
+// +build appengine appenginevm
 
 package kami
 


### PR DESCRIPTION
With the Go 1.7 changes, the request can be modified in the handler for every request (using `r = r.WithContext(ctx)`) so that if we had middleware to grab the AppEngine context, the new request would cause a panic. I'm not sure if a fix for this will be included with the AppEngine package once it officially supports 1.7, but for those of us currently developing with 1.7 on the Flexible Environment, this is an issue. These build tag changes fixes the issue and alleviates the need for adding middleware for the flexible environment to utilize the proper context throughout the application.