### PR TITLE
Add README line discussing named-param path inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ func LoginRequired(ctx context.Context, w http.ResponseWriter, r *http.Request) 
 Named parameters and wildcards in middleware are supported now. Middleware registered under a path with a wildcard will run **after** all hierarchical middleware. 
 
 ```go
-kami.Use("/user/:id/edit", CheckAdminPermissions)
+kami.Use("/user/:id/edit", CheckAdminPermissions)  // Matches only /user/:id/edit
+kami.Use("/user/:id/edit/*", CheckAdminPermissions)  // Matches all inheriting paths, behaves like non-parameterized paths
 ```
 
 #### Vanilla net/http middleware


### PR DESCRIPTION
Behavior of path inheritance for url strings containing named parameters is confusing and different from non-named parameter urls. One way to reconcile the difference is to include a `*` wildcard. Documentation of this fix will alleviate confusion.